### PR TITLE
Modify collision reaction on PlayerController.cs to allow sliding on walls for some time

### DIFF
--- a/VetLife/Assets/Scenes/Clinic.unity
+++ b/VetLife/Assets/Scenes/Clinic.unity
@@ -50,7 +50,6 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
@@ -116,60 +115,62 @@ NavMeshSettings:
 --- !u!4 &1136931 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 812054663}
+    type: 3}
+  m_PrefabInstance: {fileID: 812054663}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &13747790 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa,
-    type: 2}
-  m_PrefabInternal: {fileID: 854519909}
+    type: 3}
+  m_PrefabInstance: {fileID: 854519909}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &17041073
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalPosition.x
       value: 7.1560273
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalPosition.y
       value: 2.4049664
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
+    - target: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
       propertyPath: m_RootOrder
       value: 17
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a42692783a540b54c9f0fc13164d74fb, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: a42692783a540b54c9f0fc13164d74fb, type: 3}
 --- !u!1 &23289845
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 23289847}
@@ -185,7 +186,8 @@ GameObject:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 23289845}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -200,7 +202,8 @@ MonoBehaviour:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 23289845}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 4.2343574, y: 14.1233, z: 0.43554688}
@@ -210,104 +213,103 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &40265274
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -10.858002
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.8950334
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &47469560
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 770560997}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10.608367
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalPosition.y
       value: -9.105034
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918694
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!1 &50345869
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 50345870}
@@ -322,7 +324,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 50345869}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -351,28 +354,33 @@ Transform:
 --- !u!4 &59134589 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 832247297}
+    type: 3}
+  m_PrefabInstance: {fileID: 832247297}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &60794549 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 614066580}
+    type: 3}
+  m_PrefabInstance: {fileID: 614066580}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &64123347 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55,
-    type: 2}
-  m_PrefabInternal: {fileID: 1258167656}
+    type: 3}
+  m_PrefabInstance: {fileID: 1258167656}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &67459971 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940,
-    type: 2}
-  m_PrefabInternal: {fileID: 908912360}
+    type: 3}
+  m_PrefabInstance: {fileID: 908912360}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &82269695
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 82269696}
@@ -389,7 +397,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 82269695}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -404,7 +413,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 82269695}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -416,63 +426,64 @@ MonoBehaviour:
 SortingGroup:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 82269695}
   m_Enabled: 1
   m_SortingLayerID: -842585515
   m_SortingLayer: -4
   m_SortingOrder: 0
 --- !u!1001 &103478041
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 10.331999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 2.217967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1380156756132020, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 1380156756132020, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_Name
       value: computer1
       objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.331999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.217967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
 --- !u!1 &108314049
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 108314050}
@@ -489,7 +500,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 108314049}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 7.9400015, y: 11.11, z: -10}
@@ -503,7 +515,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 108314049}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -528,7 +541,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 108314049}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -543,115 +557,115 @@ MonoBehaviour:
 --- !u!4 &114836058 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 418662450}
+    type: 3}
+  m_PrefabInstance: {fileID: 418662450}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &115058400
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -8.521292
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.7449665
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (2)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &127989778
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 5.161999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.884966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
+    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
       propertyPath: m_Name
       value: sink
       objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.161999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.884966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
 --- !u!1 &140456922
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 140456923}
@@ -666,7 +680,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 140456922}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -691,186 +706,189 @@ Transform:
 --- !u!4 &151052698 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55,
-    type: 2}
-  m_PrefabInternal: {fileID: 1355045695}
+    type: 3}
+  m_PrefabInstance: {fileID: 1355045695}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &152699303 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1,
-    type: 2}
-  m_PrefabInternal: {fileID: 885290721}
+    type: 3}
+  m_PrefabInstance: {fileID: 885290721}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &159288956
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1728143395}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -9.448001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.674967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.448001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.674967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &163491260 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa,
-    type: 2}
-  m_PrefabInternal: {fileID: 127989778}
+    type: 3}
+  m_PrefabInstance: {fileID: 127989778}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &177866201
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -10.838356
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885033
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &188707366
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1075977091}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.658001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 7.8349667
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.658001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.8349667
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &189196353 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1638176855}
+    type: 3}
+  m_PrefabInstance: {fileID: 1638176855}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &190788556 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1132001528}
+    type: 3}
+  m_PrefabInstance: {fileID: 1132001528}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &195784745
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 195784746}
@@ -888,7 +906,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195784745}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -906,7 +925,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195784745}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -928,7 +948,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195784745}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -941,7 +962,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195784745}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -950,532 +972,534 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   HeaderText: {fileID: 1414254399}
   ContentPanel: {fileID: 195784746}
-  OptionButtonPool: {fileID: 1366246808}
   InteractionDialog: {fileID: 1752171074}
+  OptionButtonPool: {fileID: 1366246808}
 --- !u!4 &200024518 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55,
-    type: 2}
-  m_PrefabInternal: {fileID: 668797247}
+    type: 3}
+  m_PrefabInstance: {fileID: 668797247}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &200336704 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1408332044}
+    type: 3}
+  m_PrefabInstance: {fileID: 1408332044}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &203364479
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -9.857647
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.8950334
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (1)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &208188311
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1387307655}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -7.518001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 11.574966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.518001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.574966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &208967232 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 885113599}
+    type: 3}
+  m_PrefabInstance: {fileID: 885113599}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &216886859 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 208188311}
+    type: 3}
+  m_PrefabInstance: {fileID: 208188311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &245310471 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1651137294}
+    type: 3}
+  m_PrefabInstance: {fileID: 1651137294}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &261063661 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f,
-    type: 2}
-  m_PrefabInternal: {fileID: 902508374}
+    type: 3}
+  m_PrefabInstance: {fileID: 902508374}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &262577898 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 2046995784}
+    type: 3}
+  m_PrefabInstance: {fileID: 2046995784}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &263070818 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1892985291}
+    type: 3}
+  m_PrefabInstance: {fileID: 1892985291}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &281663441 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1157020003}
+    type: 3}
+  m_PrefabInstance: {fileID: 1157020003}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &282759391 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f,
-    type: 2}
-  m_PrefabInternal: {fileID: 1450722285}
+    type: 3}
+  m_PrefabInstance: {fileID: 1450722285}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &292926891
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 665882152}
     m_Modifications:
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalPosition.x
       value: 1.0967546
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalPosition.y
       value: 11.31053
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 2}
+    - target: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c07672165b8bf3c47907803694fe0964, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: c07672165b8bf3c47907803694fe0964, type: 3}
 --- !u!1001 &326338567
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1471530336}
     m_Modifications:
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -4.294304
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 3.3649664
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1983264695016868, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 1983264695016868, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_Name
       value: clock
       objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.294304
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.3649664
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
 --- !u!1001 &332637870
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 6.1319985
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.884966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
+    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
       propertyPath: m_Name
       value: sink (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.1319985
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.884966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
 --- !u!1001 &345377816
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1275999407}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -9.448001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 6.934967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.448001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.934967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1001 &352445491
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10.561998
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.9922295
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
+    - target: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
       propertyPath: m_RootOrder
       value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 61187ee93e134004781e7a94e3ffb899, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 61187ee93e134004781e7a94e3ffb899, type: 3}
 --- !u!1001 &359256513
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 567347227}
     m_Modifications:
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.519001
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.3425627
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
+    - target: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 96db66770ad7db744a791a6944e1534e, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 96db66770ad7db744a791a6944e1534e, type: 3}
 --- !u!1001 &375351018
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1387307655}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.658001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 11.574966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.658001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.574966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &378939489 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 570846436}
+    type: 3}
+  m_PrefabInstance: {fileID: 570846436}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &382118819
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 82269696}
     m_Modifications:
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10.401999
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.86503315
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918694
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
 --- !u!1 &382173736
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 382173737}
@@ -1490,7 +1514,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 382173736}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -1506,406 +1531,407 @@ Transform:
 --- !u!4 &389512062 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 1096077348}
+    type: 3}
+  m_PrefabInstance: {fileID: 1096077348}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &394020969
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.375124
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.82138824
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
+    - target: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
       propertyPath: m_RootOrder
       value: 11
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 461296ad3c85ccf4490e650dfe1072de, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 461296ad3c85ccf4490e650dfe1072de, type: 3}
 --- !u!4 &413348115 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1293336834}
+    type: 3}
+  m_PrefabInstance: {fileID: 1293336834}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &414145332
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1789009080}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.8833008
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 15.029769
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.05859375
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.8833008
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.029769
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05859375
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!1001 &418662450
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1075977091}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -9.448001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 7.8349667
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.448001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.8349667
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1001 &420905678
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.5112915
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.7449665
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (4)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!4 &433549515 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1022898247}
+    type: 3}
+  m_PrefabInstance: {fileID: 1022898247}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &447912869 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1173919080}
+    type: 3}
+  m_PrefabInstance: {fileID: 1173919080}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &457445316
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.848001
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885033
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (4)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &459530729 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 1670939049}
+    type: 3}
+  m_PrefabInstance: {fileID: 1670939049}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &461251459
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -9.8480015
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.2450333
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (1)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!4 &462974054 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4998874821694610, guid: c07672165b8bf3c47907803694fe0964,
-    type: 2}
-  m_PrefabInternal: {fileID: 292926891}
+    type: 3}
+  m_PrefabInstance: {fileID: 292926891}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &467964994
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1728143395}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.658001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.674967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.658001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.674967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &478780499 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1612447551}
+    type: 3}
+  m_PrefabInstance: {fileID: 1612447551}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &485821583
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 485821584}
@@ -1923,7 +1949,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485821583}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -1942,7 +1969,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485821583}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1965,18 +1993,21 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &485821586
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485821583}
   m_CullTransparentMesh: 0
 --- !u!114 &485821587
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485821583}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1987,216 +2018,221 @@ MonoBehaviour:
 --- !u!4 &489551714 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4951480565775794, guid: a42692783a540b54c9f0fc13164d74fb,
-    type: 2}
-  m_PrefabInternal: {fileID: 17041073}
+    type: 3}
+  m_PrefabInstance: {fileID: 17041073}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &497227094 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 461251459}
+    type: 3}
+  m_PrefabInstance: {fileID: 461251459}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &503934371 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a,
-    type: 2}
-  m_PrefabInternal: {fileID: 843721451}
+    type: 3}
+  m_PrefabInstance: {fileID: 843721451}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &506215694
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 382173737}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.1153953
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -8.625033
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1 (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1153953
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.625033
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!4 &525745741 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 797894280}
+    type: 3}
+  m_PrefabInstance: {fileID: 797894280}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &545311843 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f,
-    type: 2}
-  m_PrefabInternal: {fileID: 965889959}
+    type: 3}
+  m_PrefabInstance: {fileID: 965889959}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &545879484 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 203364479}
+    type: 3}
+  m_PrefabInstance: {fileID: 203364479}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &553175462 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 2126067039}
+    type: 3}
+  m_PrefabInstance: {fileID: 2126067039}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &557185102
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.8676467
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.8950334
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (4)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &560348785
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.848001
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.2450333
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (3)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1 &567347226
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 567347227}
@@ -2211,7 +2247,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 567347226}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -2225,189 +2262,190 @@ Transform:
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &570846436
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -8.828001
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885033
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (2)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &593670181 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 727684861}
+    type: 3}
+  m_PrefabInstance: {fileID: 727684861}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &608275369 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 188707366}
+    type: 3}
+  m_PrefabInstance: {fileID: 188707366}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &612388848
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalPosition.x
       value: 5.1404653
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.823504
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 212356405984308402, guid: ed9dc2644044b4a4397bbdf958b26be2,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212356405984308402, guid: ed9dc2644044b4a4397bbdf958b26be2,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
 --- !u!1001 &614066580
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.848001
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885033
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (3)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &638754506 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e,
-    type: 2}
-  m_PrefabInternal: {fileID: 382118819}
+    type: 3}
+  m_PrefabInstance: {fileID: 382118819}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &665882151
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 665882152}
@@ -2422,7 +2460,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 665882151}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -2434,67 +2473,67 @@ Transform:
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &668797247
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 382173737}
     m_Modifications:
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.516071
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalPosition.y
       value: -11.04
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 212705038086332036, guid: 9498899558df9ba49a033c352e334a55,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212705038086332036, guid: 9498899558df9ba49a033c352e334a55,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 212705038086332036, guid: 9498899558df9ba49a033c352e334a55,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 9498899558df9ba49a033c352e334a55, type: 3}
 --- !u!1 &675360956
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 675360958}
@@ -2510,7 +2549,8 @@ GameObject:
 Grid:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 675360956}
   m_Enabled: 1
   m_CellSize: {x: 1, y: 1, z: 0}
@@ -2521,7 +2561,8 @@ Grid:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 675360956}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -2532,76 +2573,78 @@ Transform:
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &682328538
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 7.1819987
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -10.931746
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_Name
       value: chairComfy2 (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.1819987
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.931746
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &687851062 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e,
-    type: 2}
-  m_PrefabInternal: {fileID: 1814399947}
+    type: 3}
+  m_PrefabInstance: {fileID: 1814399947}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &688081113 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 682328538}
+    type: 3}
+  m_PrefabInstance: {fileID: 682328538}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &689280799
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 689280803}
@@ -2619,7 +2662,8 @@ GameObject:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 689280799}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -2635,7 +2679,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 689280799}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -2656,7 +2701,8 @@ MonoBehaviour:
 Canvas:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 689280799}
   m_Enabled: 1
   serializedVersion: 3
@@ -2676,7 +2722,8 @@ Canvas:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 689280799}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -2692,76 +2739,78 @@ RectTransform:
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!1001 &727684861
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 5.182861
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -10.931746
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_Name
       value: chairComfy2
       objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.182861
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.931746
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &731678020 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa,
-    type: 2}
-  m_PrefabInternal: {fileID: 103478041}
+    type: 3}
+  m_PrefabInstance: {fileID: 103478041}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &751687592 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa,
-    type: 2}
-  m_PrefabInternal: {fileID: 1121895876}
+    type: 3}
+  m_PrefabInstance: {fileID: 1121895876}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &754386758
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 754386759}
@@ -2776,7 +2825,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 754386758}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -2791,7 +2841,8 @@ Transform:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 763311903}
@@ -2806,7 +2857,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 763311902}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -2819,61 +2871,62 @@ Transform:
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &763559185
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 5.3419986
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -6.1250334
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
+    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
       propertyPath: m_Name
       value: sink
       objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.3419986
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.1250334
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
 --- !u!4 &770102832 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b,
-    type: 2}
-  m_PrefabInternal: {fileID: 1433368052}
+    type: 3}
+  m_PrefabInstance: {fileID: 1433368052}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &770560996
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 770560997}
@@ -2890,7 +2943,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 770560996}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -2905,7 +2959,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 770560996}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -2917,236 +2972,236 @@ MonoBehaviour:
 SortingGroup:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 770560996}
   m_Enabled: 1
   m_SortingLayerID: -842585515
   m_SortingLayer: -4
   m_SortingOrder: 0
 --- !u!1001 &797894280
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 6.1819987
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -10.931746
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_Name
       value: chairComfy2 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.1819987
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.931746
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &799920026 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb,
-    type: 2}
-  m_PrefabInternal: {fileID: 946878235}
+    type: 3}
+  m_PrefabInstance: {fileID: 946878235}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &804084117
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1275999407}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.658001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 6.934967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.658001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.934967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1001 &812054663
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 770560997}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 11.391997
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -9.105034
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918694
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.391997
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.105034
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918694
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!4 &818846040 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 560348785}
+    type: 3}
+  m_PrefabInstance: {fileID: 560348785}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &826350147
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1387307655}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -11.368001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 11.574966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.368001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.574966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1 &828742120
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 828742123}
@@ -3163,7 +3218,8 @@ GameObject:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 828742120}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -3181,7 +3237,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 828742120}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -3195,7 +3252,8 @@ MonoBehaviour:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 828742120}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -3205,169 +3263,169 @@ Transform:
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &832247297
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -9.838001
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885034
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (1)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &833620474
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1275999407}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -11.368001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 6.934967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.368001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.934967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &837191464 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb,
-    type: 2}
-  m_PrefabInternal: {fileID: 326338567}
+    type: 3}
+  m_PrefabInstance: {fileID: 326338567}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &843721451
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 883273988}
     m_Modifications:
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalPosition.x
       value: -11.828001
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.016449
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
+    - target: {fileID: 4525570001237324, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 0c1f2119228e8d04fa64b60886cdd78a, type: 3}
 --- !u!4 &844869218 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 1421624748}
+    type: 3}
+  m_PrefabInstance: {fileID: 1421624748}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &846088988
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 846088990}
@@ -3383,7 +3441,8 @@ GameObject:
 Grid:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 846088988}
   m_Enabled: 1
   m_CellSize: {x: 1, y: 1, z: 0}
@@ -3394,7 +3453,8 @@ Grid:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 846088988}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -3405,56 +3465,56 @@ Transform:
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &854519909
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 6.351999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -6.1250334
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
+    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
       propertyPath: m_Name
       value: sink (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.351999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.1250334
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
 --- !u!1 &856696747
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 856696748}
@@ -3469,7 +3529,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 856696747}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -3487,69 +3548,70 @@ RectTransform:
 --- !u!4 &861303674 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2,
-    type: 2}
-  m_PrefabInternal: {fileID: 612388848}
+    type: 3}
+  m_PrefabInstance: {fileID: 612388848}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &862213123
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 5.611999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -2.823504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1130993143364232, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
+    - target: {fileID: 1130993143364232, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
       propertyPath: m_Name
       value: tableBooks (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.611999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.823504
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
     - target: {fileID: 212356405984308402, guid: ed9dc2644044b4a4397bbdf958b26be2,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212356405984308402, guid: ed9dc2644044b4a4397bbdf958b26be2,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ed9dc2644044b4a4397bbdf958b26be2, type: 3}
 --- !u!1 &866589447
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 866589448}
@@ -3564,7 +3626,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 866589447}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -3588,13 +3651,15 @@ Transform:
 --- !u!4 &879194809 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 345377816}
+    type: 3}
+  m_PrefabInstance: {fileID: 345377816}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &879643372
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 879643373}
@@ -3612,7 +3677,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879643372}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -3631,7 +3697,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879643372}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -3677,7 +3744,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879643372}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -3700,18 +3768,21 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &879643376
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879643372}
   m_CullTransparentMesh: 0
 --- !u!1 &883273987
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 883273988}
@@ -3726,7 +3797,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 883273987}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -3740,434 +3812,432 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &885113599
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 382173737}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.1153953
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -9.955033
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1153953
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.955033
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!1001 &885290721
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.111689
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -1.1023874
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
+    - target: {fileID: 4346200622742564, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
       propertyPath: m_RootOrder
       value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 212958886006147044, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212958886006147044, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
     - target: {fileID: 212958886006147044, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: d42323ecfb2e2b64f9f18e0e02fd6cb1, type: 3}
 --- !u!1001 &902508374
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.031998
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalPosition.y
       value: 5.5675535
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 212955185797057244, guid: f78a342c37acc3d4982b53055c12da8f,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212955185797057244, guid: f78a342c37acc3d4982b53055c12da8f,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
 --- !u!1001 &904754866
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -5.8380013
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.2450333
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (5)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &908912360
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 567347227}
     m_Modifications:
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalPosition.x
       value: -3.3042376
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.1589756
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
+    - target: {fileID: 4786962663705210, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 212481918273851318, guid: 464d1593d0e76e249b5c32934ac07940,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 464d1593d0e76e249b5c32934ac07940, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 464d1593d0e76e249b5c32934ac07940, type: 3}
 --- !u!4 &929553929 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 115058400}
+    type: 3}
+  m_PrefabInstance: {fileID: 115058400}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &934418336 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 159288956}
+    type: 3}
+  m_PrefabInstance: {fileID: 159288956}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &936235420 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 47469560}
+    type: 3}
+  m_PrefabInstance: {fileID: 47469560}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &946878235
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 883273988}
     m_Modifications:
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.8445125
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalPosition.y
       value: -4.6550336
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
+    - target: {fileID: 4617146456605138, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
       propertyPath: m_RootOrder
       value: 15
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9dbbf2390b79a25408de63c1720270cb, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 9dbbf2390b79a25408de63c1720270cb, type: 3}
 --- !u!4 &950812554 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb,
-    type: 2}
-  m_PrefabInternal: {fileID: 992156055}
+    type: 3}
+  m_PrefabInstance: {fileID: 992156055}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &965889959
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.234625
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.01351738
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
+    - target: {fileID: 4014004197500904, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
       propertyPath: m_RootOrder
       value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ce3c0a6e81dd31446a3954daf30a435f, type: 3}
 --- !u!1001 &967967244
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 567347227}
     m_Modifications:
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.1080012
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.19496632
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
+    - target: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ac377f63ab49d3e4cb283e3fc6832b2d, type: 3}
 --- !u!4 &969925331 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 1456517887}
+    type: 3}
+  m_PrefabInstance: {fileID: 1456517887}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &975378462
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 975378463}
@@ -4185,7 +4255,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 975378462}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -4206,7 +4277,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 975378462}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -4229,18 +4301,21 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &975378465
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 975378462}
   m_CullTransparentMesh: 0
 --- !u!114 &975378466
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 975378462}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -4271,7 +4346,8 @@ MonoBehaviour:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 977890059}
@@ -4286,7 +4362,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 977890058}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -4298,206 +4375,205 @@ Transform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &992156055
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1789009080}
     m_Modifications:
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalPosition.x
       value: 1.6656637
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalPosition.y
       value: 14.879767
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.05859375
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
+    - target: {fileID: 4753024229776112, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: eb98051b3a780e04fb266ecf73e901bb, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: eb98051b3a780e04fb266ecf73e901bb, type: 3}
 --- !u!1001 &1002641033
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalPosition.x
       value: 8.025377
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalPosition.y
       value: 12.199764
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 2}
+    - target: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920, type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 38918acadce237242bca4a57734b1920, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 38918acadce237242bca4a57734b1920, type: 3}
 --- !u!4 &1003233947 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4435944219890582, guid: 461296ad3c85ccf4490e650dfe1072de,
-    type: 2}
-  m_PrefabInternal: {fileID: 394020969}
+    type: 3}
+  m_PrefabInstance: {fileID: 394020969}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1022898247
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1075977091}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -7.518001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 7.8349667
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.518001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.8349667
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &1037902321 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a,
-    type: 2}
-  m_PrefabInternal: {fileID: 1583667407}
+    type: 3}
+  m_PrefabInstance: {fileID: 1583667407}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1055281421
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1275999407}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -5.5880013
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 6.934967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5880013
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.934967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1 &1075977090
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1075977091}
@@ -4512,7 +4588,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1075977090}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -4529,503 +4606,504 @@ Transform:
 --- !u!4 &1093839014 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174,
-    type: 2}
-  m_PrefabInternal: {fileID: 1916741910}
+    type: 3}
+  m_PrefabInstance: {fileID: 1916741910}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1096077348
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1789009080}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 1.6733007
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 15.029769
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.05859375
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.6733007
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.029769
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05859375
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!1001 &1121895876
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 8.161999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 1.8749666
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
+    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
       propertyPath: m_Name
       value: sink (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.161999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8749666
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
 --- !u!1001 &1132001528
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.5212913
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.7449665
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (3)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!4 &1140030683 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1055281421}
+    type: 3}
+  m_PrefabInstance: {fileID: 1055281421}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1149476435 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4065656041797320, guid: 38918acadce237242bca4a57734b1920,
-    type: 2}
-  m_PrefabInternal: {fileID: 1002641033}
+    type: 3}
+  m_PrefabInstance: {fileID: 1002641033}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1157020003
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1387307655}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -5.5880013
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 11.574966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5880013
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.574966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &1167431087 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4037575640718250, guid: ac377f63ab49d3e4cb283e3fc6832b2d,
-    type: 2}
-  m_PrefabInternal: {fileID: 967967244}
+    type: 3}
+  m_PrefabInstance: {fileID: 967967244}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1173919080
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -8.8480015
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.2450333
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (2)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &1184231764
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalPosition.x
       value: 7.071999
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.1750336
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_RootOrder
       value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
 --- !u!4 &1187931445 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa,
-    type: 2}
-  m_PrefabInternal: {fileID: 763559185}
+    type: 3}
+  m_PrefabInstance: {fileID: 763559185}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1199950737
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1387307655}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -9.448001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 11.574966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.448001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.574966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &1202252702 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 826350147}
+    type: 3}
+  m_PrefabInstance: {fileID: 826350147}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1216404546 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4731767674889418, guid: 96db66770ad7db744a791a6944e1534e,
-    type: 2}
-  m_PrefabInternal: {fileID: 359256513}
+    type: 3}
+  m_PrefabInstance: {fileID: 359256513}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1226078634 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1393872129}
+    type: 3}
+  m_PrefabInstance: {fileID: 1393872129}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1233937022
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1728143395}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -7.518001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.674967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.518001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.674967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &1256564766 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1329352237}
+    type: 3}
+  m_PrefabInstance: {fileID: 1329352237}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1258167656
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 8.764355
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -6.2250338
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1354099699356154, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 1354099699356154, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_Name
       value: deskHorizontal1 (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.764355
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.2250338
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 9498899558df9ba49a033c352e334a55, type: 3}
 --- !u!1 &1275999406
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1275999407}
@@ -5040,7 +5118,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1275999406}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5055,127 +5134,128 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1293336834
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.8380013
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.2450333
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (4)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!4 &1294372915 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c,
-    type: 2}
-  m_PrefabInternal: {fileID: 1465890930}
+    type: 3}
+  m_PrefabInstance: {fileID: 1465890930}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1300384954
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 11.391998
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -1.8750324
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.391998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.8750324
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!1 &1300384955 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 1300384954}
+    type: 3}
+  m_PrefabInstance: {fileID: 1300384954}
+  m_PrefabAsset: {fileID: 0}
 --- !u!61 &1300384956
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1300384955}
   m_Enabled: 1
   m_Density: 1
@@ -5199,18 +5279,21 @@ BoxCollider2D:
 --- !u!4 &1300384957 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 1300384954}
+    type: 3}
+  m_PrefabInstance: {fileID: 1300384954}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1300964894 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4825482887661224, guid: 61187ee93e134004781e7a94e3ffb899,
-    type: 2}
-  m_PrefabInternal: {fileID: 352445491}
+    type: 3}
+  m_PrefabInstance: {fileID: 352445491}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1305766485
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1305766486}
@@ -5228,7 +5311,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1305766485}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5247,7 +5331,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1305766485}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -5293,7 +5378,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1305766485}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -5316,79 +5402,83 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &1305766489
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1305766485}
   m_CullTransparentMesh: 0
 --- !u!4 &1312707909 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 414145332}
+    type: 3}
+  m_PrefabInstance: {fileID: 414145332}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1326546416 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074,
-    type: 2}
-  m_PrefabInternal: {fileID: 2047796960}
+    type: 3}
+  m_PrefabInstance: {fileID: 2047796960}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1329352237
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1728143395}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -5.5880013
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.674967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5880013
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.674967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1 &1335756487
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1335756488}
@@ -5403,7 +5493,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335756487}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -5426,120 +5517,121 @@ Transform:
 --- !u!4 &1336320269 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 804084117}
+    type: 3}
+  m_PrefabInstance: {fileID: 804084117}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1340736319
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 11.4019985
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -0.3250332
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 1837954221163098, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_Name
       value: deskVertical1
       objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.4019985
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.3250332
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!4 &1349581005 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1233937022}
+    type: 3}
+  m_PrefabInstance: {fileID: 1233937022}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1355045695
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 10.742327
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -6.220641
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1354099699356154, guid: 9498899558df9ba49a033c352e334a55, type: 2}
+    - target: {fileID: 1354099699356154, guid: 9498899558df9ba49a033c352e334a55, type: 3}
       propertyPath: m_Name
       value: deskHorizontal1 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.742327
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.220641
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332054102008224, guid: 9498899558df9ba49a033c352e334a55, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 212705038086332036, guid: 9498899558df9ba49a033c352e334a55,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9498899558df9ba49a033c352e334a55, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 9498899558df9ba49a033c352e334a55, type: 3}
 --- !u!1 &1366246806
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1366246807}
@@ -5555,7 +5647,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1366246806}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5568,71 +5661,74 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1366246806}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ba0e79e697b5578458d0a33b060e3d8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Prefab: {fileID: 1054295731070054, guid: 7940eb82902624146981b58e01f214ef, type: 2}
+  Prefab: {fileID: 1054295731070054, guid: 7940eb82902624146981b58e01f214ef, type: 3}
 --- !u!4 &1370772190 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 1989648522}
+    type: 3}
+  m_PrefabInstance: {fileID: 1989648522}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1372222473
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalPosition.x
       value: 5.667338
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalPosition.y
       value: 2.4100971
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
+    - target: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7a7208bd93594064398d21247e6fbe89, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 7a7208bd93594064398d21247e6fbe89, type: 3}
 --- !u!4 &1380208465 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1199950737}
+    type: 3}
+  m_PrefabInstance: {fileID: 1199950737}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1387307654
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1387307655}
@@ -5647,7 +5743,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1387307654}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5665,7 +5762,8 @@ Transform:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1389061915}
@@ -5680,7 +5778,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1389061914}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5703,122 +5802,122 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1393872129
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -9.521292
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.7449665
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (1)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &1399002557
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1075977091}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -5.5880013
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 7.8349667
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5880013
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.8349667
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &1403308959 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 457445316}
+    type: 3}
+  m_PrefabInstance: {fileID: 457445316}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1406075382
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1406075383}
@@ -5838,7 +5937,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1406075382}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5851,7 +5951,8 @@ Transform:
 TilemapRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1406075382}
   m_Enabled: 1
   m_CastShadows: 0
@@ -5861,6 +5962,7 @@ TilemapRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -5883,17 +5985,19 @@ TilemapRenderer:
   m_SortingLayer: -5
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0, y: 0.5, z: 0}
+  m_ChunkCullingBounds: {x: 0, y: 1, z: 0}
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0
+  m_Mode: 0
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
 --- !u!1839735485 &1406075385
 Tilemap:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1406075382}
   m_Enabled: 1
   m_Tiles:
@@ -6903,7 +7007,8 @@ Tilemap:
 CompositeCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1406075382}
   m_Enabled: 1
   m_Density: 1
@@ -7154,7 +7259,8 @@ Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1406075382}
   m_BodyType: 2
   m_Simulated: 1
@@ -7173,7 +7279,8 @@ Rigidbody2D:
 TilemapCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1406075382}
   m_Enabled: 1
   m_Density: 1
@@ -7183,61 +7290,61 @@ TilemapCollider2D:
   m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
 --- !u!1001 &1408332044
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1275999407}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -7.518001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 6.934967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.518001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.934967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1 &1414254397
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1414254398}
@@ -7254,7 +7361,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1414254397}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -7272,7 +7380,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1414254397}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -7305,127 +7414,127 @@ MonoBehaviour:
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1414254397}
   m_CullTransparentMesh: 0
 --- !u!1001 &1421624748
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.8676467
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.8950334
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (3)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &1433368052
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.427813
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.5309181
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
+    - target: {fileID: 4610989309459604, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
       propertyPath: m_RootOrder
       value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 212118667611520460, guid: a023d708df7ad8544a71cca48cc1991b,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212118667611520460, guid: a023d708df7ad8544a71cca48cc1991b,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
     - target: {fileID: 212118667611520460, guid: a023d708df7ad8544a71cca48cc1991b,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a023d708df7ad8544a71cca48cc1991b, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: a023d708df7ad8544a71cca48cc1991b, type: 3}
 --- !u!1 &1447904263
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1447904264}
@@ -7440,7 +7549,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1447904263}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 14.856698, y: 3.0902321, z: -0.05859375}
@@ -7457,61 +7567,62 @@ Transform:
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1450722285
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 8.021999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.624966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 1565738991727934, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
+    - target: {fileID: 1565738991727934, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
       propertyPath: m_Name
       value: cart1 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.021999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.624966
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916849235957954, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f78a342c37acc3d4982b53055c12da8f, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: f78a342c37acc3d4982b53055c12da8f, type: 3}
 --- !u!4 &1453880740 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 1900828757}
+    type: 3}
+  m_PrefabInstance: {fileID: 1900828757}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1455246225
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1455246226}
@@ -7531,7 +7642,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1455246225}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -7544,7 +7656,8 @@ Transform:
 TilemapRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1455246225}
   m_Enabled: 1
   m_CastShadows: 0
@@ -7554,6 +7667,7 @@ TilemapRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -7580,13 +7694,15 @@ TilemapRenderer:
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0
+  m_Mode: 0
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
 --- !u!1839735485 &1455246228
 Tilemap:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1455246225}
   m_Enabled: 1
   m_Tiles:
@@ -9150,7 +9266,8 @@ Tilemap:
 CompositeCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1455246225}
   m_Enabled: 1
   m_Density: 1
@@ -9401,7 +9518,8 @@ Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1455246225}
   m_BodyType: 2
   m_Simulated: 1
@@ -9420,7 +9538,8 @@ Rigidbody2D:
 TilemapCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1455246225}
   m_Enabled: 1
   m_Density: 1
@@ -9430,108 +9549,107 @@ TilemapCollider2D:
   m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
 --- !u!1001 &1456517887
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 8.181999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -10.931746
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_Name
       value: chairComfy2 (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.181999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.931746
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &1465890930
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.081999
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalPosition.y
       value: 10.634966
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
+    - target: {fileID: 4092893386127886, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 53232b497ded8ca429bdb89ba700588c, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 53232b497ded8ca429bdb89ba700588c, type: 3}
 --- !u!1 &1465965993
 GameObject:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1465965994}
@@ -9548,7 +9666,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1465965993}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -9561,7 +9680,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1465965993}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -9599,7 +9719,8 @@ MonoBehaviour:
 MonoBehaviour:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1465965993}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -9610,7 +9731,8 @@ MonoBehaviour:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1471530336}
@@ -9625,7 +9747,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1471530335}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5086975, y: 6.9948015, z: 0.046675056}
@@ -9641,18 +9764,21 @@ Transform:
 --- !u!4 &1481226934 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 1889452283}
+    type: 3}
+  m_PrefabInstance: {fileID: 1889452283}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1491574267 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf,
-    type: 2}
-  m_PrefabInternal: {fileID: 1641026072}
+    type: 3}
+  m_PrefabInstance: {fileID: 1641026072}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1512594096
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1512594097}
@@ -9669,7 +9795,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1512594096}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -9687,7 +9814,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1512594096}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -9710,520 +9838,532 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &1512594099
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1512594096}
   m_CullTransparentMesh: 0
 --- !u!4 &1532327126 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733,
-    type: 2}
-  m_PrefabInternal: {fileID: 1850824032}
+    type: 3}
+  m_PrefabInstance: {fileID: 1850824032}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1562198334 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa,
-    type: 2}
-  m_PrefabInternal: {fileID: 332637870}
+    type: 3}
+  m_PrefabInstance: {fileID: 332637870}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1566122788 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1399002557}
+    type: 3}
+  m_PrefabInstance: {fileID: 1399002557}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1571933496 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9,
-    type: 2}
-  m_PrefabInternal: {fileID: 1667334388}
+    type: 3}
+  m_PrefabInstance: {fileID: 1667334388}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1583667407
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 5.2465177
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalPosition.y
       value: 5.7849665
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
+    - target: {fileID: 4355246888164648, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 212377651990575624, guid: c42a6edd12949164691a4daff1cbd26a,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212377651990575624, guid: c42a6edd12949164691a4daff1cbd26a,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c42a6edd12949164691a4daff1cbd26a, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: c42a6edd12949164691a4daff1cbd26a, type: 3}
 --- !u!4 &1588714074 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 467964994}
+    type: 3}
+  m_PrefabInstance: {fileID: 467964994}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1602402830 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02,
-    type: 2}
-  m_PrefabInternal: {fileID: 1962917990}
+    type: 3}
+  m_PrefabInstance: {fileID: 1962917990}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1604565276 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c,
-    type: 2}
-  m_PrefabInternal: {fileID: 1972676459}
+    type: 3}
+  m_PrefabInstance: {fileID: 1972676459}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1610678809 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 375351018}
+    type: 3}
+  m_PrefabInstance: {fileID: 375351018}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1612447551
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -10.834711
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: -6.2450333
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &1638176855
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -4.5112915
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 1.7449665
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_Name
       value: chairComfy1 (6)
       objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.5112915
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.7449665
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &1641026072
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 382173737}
     m_Modifications:
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.136351
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalPosition.y
       value: -9.518467
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
+    - target: {fileID: 4457907810818612, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 212729786976840334, guid: a411c0b14f71f1047b34f2c98eee7abf,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212729786976840334, guid: a411c0b14f71f1047b34f2c98eee7abf,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: a411c0b14f71f1047b34f2c98eee7abf, type: 3}
 --- !u!1001 &1651137294
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1728143395}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -11.368001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 10.674967
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.368001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.674967
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!1001 &1653679825
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalPosition.x
       value: 7.94
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalPosition.y
       value: 11.11
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
+    - target: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 114765402753051608, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
+        type: 3}
       propertyPath: GestureHandler
       value: 
       objectReference: {fileID: 23289846}
     - target: {fileID: 114765402753051608, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
+        type: 3}
       propertyPath: Speed
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 210256803829264196, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
-      propertyPath: m_SortingLayerID
-      value: 1756804087
-      objectReference: {fileID: 0}
-    - target: {fileID: 210256803829264196, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
-      propertyPath: m_SortingLayer
-      value: -3
-      objectReference: {fileID: 0}
-    - target: {fileID: 210102630389374580, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
-      propertyPath: m_SortingLayerID
-      value: 1756804087
-      objectReference: {fileID: 0}
-    - target: {fileID: 210102630389374580, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
-      propertyPath: m_SortingLayer
-      value: -3
-      objectReference: {fileID: 0}
-    - target: {fileID: 50064184070387890, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
-      propertyPath: m_Constraints
-      value: 4
-      objectReference: {fileID: 0}
     - target: {fileID: 114765402753051608, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
+        type: 3}
       propertyPath: InteractionDialog
       value: 
       objectReference: {fileID: 195784749}
     - target: {fileID: 114765402753051608, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-        type: 2}
+        type: 3}
       propertyPath: PopupSnackbar
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 114765402753051608, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
+        type: 3}
+      propertyPath: collisionTimerThreshold
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 210256803829264196, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: 1756804087
+      objectReference: {fileID: 0}
+    - target: {fileID: 210256803829264196, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
+        type: 3}
+      propertyPath: m_SortingLayer
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 210102630389374580, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: 1756804087
+      objectReference: {fileID: 0}
+    - target: {fileID: 210102630389374580, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
+        type: 3}
+      propertyPath: m_SortingLayer
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 50064184070387890, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 0e422d9f3d1cfea4d88cba423d0dabde, type: 3}
 --- !u!4 &1653679826 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4521803028209680, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-    type: 2}
-  m_PrefabInternal: {fileID: 1653679825}
+    type: 3}
+  m_PrefabInstance: {fileID: 1653679825}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1653679827 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1614470125969876, guid: 0e422d9f3d1cfea4d88cba423d0dabde,
-    type: 2}
-  m_PrefabInternal: {fileID: 1653679825}
+    type: 3}
+  m_PrefabInstance: {fileID: 1653679825}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1667334388
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 763311903}
     m_Modifications:
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.828001
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalPosition.y
       value: 11.314966
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 2}
+    - target: {fileID: 4736807497168860, guid: ec4386fca411f9642856161b527841b9, type: 3}
       propertyPath: m_RootOrder
       value: 20
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ec4386fca411f9642856161b527841b9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ec4386fca411f9642856161b527841b9, type: 3}
 --- !u!1001 &1670939049
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -8.847647
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.8950334
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (2)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &1686207000 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 40265274}
+    type: 3}
+  m_PrefabInstance: {fileID: 40265274}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1692515459 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 420905678}
+    type: 3}
+  m_PrefabInstance: {fileID: 420905678}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1728143394
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1728143395}
@@ -10238,7 +10378,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1728143394}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -10253,57 +10394,58 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1730356419
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 866589448}
     m_Modifications:
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10.101999
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalPosition.y
       value: -5.7250333
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
+    - target: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
       propertyPath: m_RootOrder
       value: 12
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: dc1de34712deb5c40a5ff43b6b61fafa, type: 3}
 --- !u!4 &1730802623 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 1340736319}
+    type: 3}
+  m_PrefabInstance: {fileID: 1340736319}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1731071207
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1731071208}
@@ -10320,7 +10462,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731071207}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -10338,7 +10481,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731071207}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -10361,18 +10505,21 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &1731071210
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731071207}
   m_CullTransparentMesh: 0
 --- !u!1 &1734059766
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1734059768}
@@ -10388,7 +10535,8 @@ GameObject:
 Grid:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1734059766}
   m_Enabled: 1
   m_CellSize: {x: 1, y: 1, z: 0}
@@ -10399,7 +10547,8 @@ Grid:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1734059766}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -10412,13 +10561,15 @@ Transform:
 --- !u!4 &1734646161 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b,
-    type: 2}
-  m_PrefabInternal: {fileID: 1801150958}
+    type: 3}
+  m_PrefabInstance: {fileID: 1801150958}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1752171073
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1752171074}
@@ -10436,7 +10587,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1752171073}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -10456,7 +10608,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1752171073}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -10479,40 +10632,33 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &1752171076
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1752171073}
   m_CullTransparentMesh: 0
 --- !u!114 &1752171077
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1752171073}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 247442469, guid: f7b54ff4a43d4fcf81b4538b678e0bcc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_SurfaceParent: {fileID: 0}
-  m_FreezeUpdates: 0
-  m_VolumeType: 1
-  m_SphereRadius: 2
-  m_HalfBoxExtents: {x: 4, y: 4, z: 4}
-  m_LodType: 1
-  m_NumUpdatesBeforeRemoval: 10
-  m_SecondsBetweenUpdates: 2.5
-  m_Layer: 0
-  m_Material: {fileID: 0}
-  m_EnableCollisions: 1
 --- !u!1 &1754715365
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1754715366}
@@ -10529,7 +10675,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1754715365}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -10544,7 +10691,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1754715365}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -10556,7 +10704,8 @@ MonoBehaviour:
 SortingGroup:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1754715365}
   m_Enabled: 1
   m_SortingLayerID: -842585515
@@ -10565,74 +10714,77 @@ SortingGroup:
 --- !u!4 &1761028565 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa,
-    type: 2}
-  m_PrefabInternal: {fileID: 1924831328}
+    type: 3}
+  m_PrefabInstance: {fileID: 1924831328}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1762749637
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1075977091}
     m_Modifications:
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -11.368001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 7.8349667
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
+    - target: {fileID: 1299552434290372, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
       propertyPath: m_Name
       value: kennel (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.368001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.8349667
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 212748211005679824, guid: bcd65e2a8a29dfc478900174d759e9e7,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: bcd65e2a8a29dfc478900174d759e9e7, type: 3}
 --- !u!4 &1767137148 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4138799708971540, guid: 7a7208bd93594064398d21247e6fbe89,
-    type: 2}
-  m_PrefabInternal: {fileID: 1372222473}
+    type: 3}
+  m_PrefabInstance: {fileID: 1372222473}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1779980462 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4801509797970248, guid: ed9dc2644044b4a4397bbdf958b26be2,
-    type: 2}
-  m_PrefabInternal: {fileID: 862213123}
+    type: 3}
+  m_PrefabInstance: {fileID: 862213123}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1789009079
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1789009080}
@@ -10649,7 +10801,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1789009079}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 8.5086975, y: -6.9948015, z: -0.046675056}
@@ -10665,7 +10818,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1789009079}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -10677,7 +10831,8 @@ MonoBehaviour:
 SortingGroup:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1789009079}
   m_Enabled: 1
   m_SortingLayerID: -842585515
@@ -10687,7 +10842,8 @@ SortingGroup:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1800028816}
@@ -10705,14 +10861,16 @@ GameObject:
 AudioListener:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800028813}
   m_Enabled: 1
 --- !u!20 &1800028815
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800028813}
   m_Enabled: 1
   serializedVersion: 2
@@ -10721,6 +10879,7 @@ Camera:
   m_projectionMatrixMode: 1
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -10752,7 +10911,8 @@ Camera:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800028813}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 7.9400015, y: 11.11, z: -10}
@@ -10765,7 +10925,8 @@ Transform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800028813}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -10792,52 +10953,52 @@ MonoBehaviour:
     m_TypeName: Cinemachine.CinemachineBrain+VcamEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1801150958
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10.809999
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.2349663
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
+    - target: {fileID: 4277264188865732, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 87e297adcb0051046bb56cc5f5d4437b, type: 3}
 --- !u!1 &1804102796
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1804102797}
@@ -10855,7 +11016,8 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1804102796}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -10868,7 +11030,8 @@ Transform:
 TilemapRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1804102796}
   m_Enabled: 1
   m_CastShadows: 0
@@ -10878,6 +11041,7 @@ TilemapRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -10904,13 +11068,15 @@ TilemapRenderer:
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0
+  m_Mode: 0
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
 --- !u!1839735485 &1804102799
 Tilemap:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1804102796}
   m_Enabled: 1
   m_Tiles:
@@ -28006,7 +28172,8 @@ Tilemap:
 PolygonCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1804102796}
   m_Enabled: 1
   m_Density: 1
@@ -28032,426 +28199,422 @@ PolygonCollider2D:
       - {x: 28.006374, y: 32.99542}
       - {x: 28.004213, y: 32.99758}
 --- !u!1001 &1814399947
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 82269696}
     m_Modifications:
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 10.401999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -1.4550333
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918694
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1324262802097604, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
+    - target: {fileID: 1324262802097604, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
       propertyPath: m_Name
       value: stool (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.401999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.4550333
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918694
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042615690628214, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3217df79ca5dc3c4a998384380a0286e, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 3217df79ca5dc3c4a998384380a0286e, type: 3}
 --- !u!4 &1816447766 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 833620474}
+    type: 3}
+  m_PrefabInstance: {fileID: 833620474}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1850824032
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1471530336}
     m_Modifications:
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalPosition.x
       value: -11.718
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.9549665
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
+    - target: {fileID: 4441059303863968, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
       propertyPath: m_RootOrder
       value: 14
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ed4828eaae14e2446beba19cdd982733, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ed4828eaae14e2446beba19cdd982733, type: 3}
 --- !u!1001 &1889452283
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -4.8380013
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885033
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (6)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &1892985291
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
+      propertyPath: m_Name
+      value: chairComfy1 (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -5.5112915
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.7449665
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
-    - target: {fileID: 1609862967775668, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-      propertyPath: m_Name
-      value: chairComfy1 (5)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1001 &1900828757
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 140456923}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_Name
+      value: chairComfy2 (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.x
       value: -5.848001
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.y
       value: -10.885033
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_Name
-      value: chairComfy2 (5)
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!4 &1908842805 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4879775727811858, guid: dc1de34712deb5c40a5ff43b6b61fafa,
-    type: 2}
-  m_PrefabInternal: {fileID: 1730356419}
+    type: 3}
+  m_PrefabInstance: {fileID: 1730356419}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1910126942 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074,
-    type: 2}
-  m_PrefabInternal: {fileID: 1184231764}
+    type: 3}
+  m_PrefabInstance: {fileID: 1184231764}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1916741910
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalPosition.x
       value: 7.852411
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalPosition.y
       value: 11.067499
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
+    - target: {fileID: 4547229201433948, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
       propertyPath: m_RootOrder
       value: 12
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 099c9f2b7f8eabc4bb6e7320015f4174, type: 3}
 --- !u!1001 &1924831328
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 9.1519985
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 1.8749666
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
+    - target: {fileID: 1409479675970902, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
       propertyPath: m_Name
       value: sink (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.1519985
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8749666
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4332003989243442, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 57abc3892ad72274493735607a39a9fa, type: 3}
 --- !u!1001 &1962917990
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalPosition.x
       value: 11.427813
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalPosition.y
       value: -1.275033
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
+    - target: {fileID: 4137465743533618, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
       propertyPath: m_RootOrder
       value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 212376366484962724, guid: ae4c9e53c9b5d9848822e6a0b74e5a02,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212376366484962724, guid: ae4c9e53c9b5d9848822e6a0b74e5a02,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
     - target: {fileID: 212376366484962724, guid: ae4c9e53c9b5d9848822e6a0b74e5a02,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: ae4c9e53c9b5d9848822e6a0b74e5a02, type: 3}
 --- !u!1 &1971926484
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1971926485}
@@ -28468,7 +28631,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1971926484}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -28487,7 +28651,8 @@ RectTransform:
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1971926484}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -28510,410 +28675,413 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!222 &1971926487
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1971926484}
   m_CullTransparentMesh: 0
 --- !u!1001 &1972676459
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10.830698
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalPosition.y
       value: 5.9901505
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
+    - target: {fileID: 4191910792874382, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
       propertyPath: m_RootOrder
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 212154402672649280, guid: a8e7d873c226fcf41af14e7cb5a5710c,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212154402672649280, guid: a8e7d873c226fcf41af14e7cb5a5710c,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: a8e7d873c226fcf41af14e7cb5a5710c, type: 3}
 --- !u!4 &1980465578 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 177866201}
+    type: 3}
+  m_PrefabInstance: {fileID: 177866201}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1989648522
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 567347227}
     m_Modifications:
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalPosition.x
       value: -3.118001
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.16503334
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
+    - target: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 212606094834670690, guid: 783084e53bd853f43acf5eb99d5489e9,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingOrder
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 783084e53bd853f43acf5eb99d5489e9, type: 3}
 --- !u!1001 &2046995784
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -5.8676467
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -2.8950334
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
+    - target: {fileID: 1343399189750880, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
       propertyPath: m_Name
       value: chairComfy2 (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.8676467
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8950334
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212740242063127816, guid: 28c393248c234e34994a9ca41118ec21,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 28c393248c234e34994a9ca41118ec21, type: 3}
 --- !u!1001 &2047796960
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50345870}
     m_Modifications:
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 11.181999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -2.8250332
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.011918695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1027820152558720, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
+    - target: {fileID: 1027820152558720, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
       propertyPath: m_Name
       value: hazardBin
       objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.181999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8250332
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.011918695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328345210485080, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 212809017828293188, guid: 95695c2e48e337049911533d1d5e9074,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212809017828293188, guid: 95695c2e48e337049911533d1d5e9074,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 95695c2e48e337049911533d1d5e9074, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 95695c2e48e337049911533d1d5e9074, type: 3}
 --- !u!4 &2056000678 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4079233724374808, guid: 783084e53bd853f43acf5eb99d5489e9,
-    type: 2}
-  m_PrefabInternal: {fileID: 506215694}
+    type: 3}
+  m_PrefabInstance: {fileID: 506215694}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2088179579 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4558680019488226, guid: 28c393248c234e34994a9ca41118ec21,
-    type: 2}
-  m_PrefabInternal: {fileID: 557185102}
+    type: 3}
+  m_PrefabInstance: {fileID: 557185102}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2089565520 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4794312197080788, guid: bcd65e2a8a29dfc478900174d759e9e7,
-    type: 2}
-  m_PrefabInternal: {fileID: 1762749637}
+    type: 3}
+  m_PrefabInstance: {fileID: 1762749637}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2093972285 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1,
-    type: 2}
-  m_PrefabInternal: {fileID: 904754866}
+    type: 3}
+  m_PrefabInstance: {fileID: 904754866}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2108197196
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 665882152}
     m_Modifications:
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.17046595
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalPosition.y
       value: 11.31053
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
+    - target: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 79f7ea2cd40491143a7ba84bf699135d, type: 3}
 --- !u!4 &2108197199 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4121304158149414, guid: 79f7ea2cd40491143a7ba84bf699135d,
-    type: 2}
-  m_PrefabInternal: {fileID: 2108197196}
+    type: 3}
+  m_PrefabInstance: {fileID: 2108197196}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2108746452
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1335756488}
     m_Modifications:
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalPosition.x
       value: 6.1728034
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalPosition.y
       value: 5.714967
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
+    - target: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 212062877317549208, guid: a734a83fd0a0bff4e86b075cb5b238c8,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: 107443093
       objectReference: {fileID: 0}
     - target: {fileID: 212062877317549208, guid: a734a83fd0a0bff4e86b075cb5b238c8,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: a734a83fd0a0bff4e86b075cb5b238c8, type: 3}
 --- !u!4 &2108746455 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4520369909917938, guid: a734a83fd0a0bff4e86b075cb5b238c8,
-    type: 2}
-  m_PrefabInternal: {fileID: 2108746452}
+    type: 3}
+  m_PrefabInstance: {fileID: 2108746452}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2126067039
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 1389061915}
     m_Modifications:
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.x
       value: -10.508001
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.7449665
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.011918695
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
+    - target: {fileID: 4058103322232562, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -842585515
       objectReference: {fileID: 0}
     - target: {fileID: 212540701960051170, guid: 594dc61b7010a524bb9c565deba563c1,
-        type: 2}
+        type: 3}
       propertyPath: m_SortingLayer
       value: -4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 594dc61b7010a524bb9c565deba563c1, type: 3}
 --- !u!1 &2135631720
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2135631721}
@@ -28928,7 +29096,8 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2135631720}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/VetLife/Assets/Scripts/Player/PlayerController.cs
+++ b/VetLife/Assets/Scripts/Player/PlayerController.cs
@@ -201,6 +201,15 @@ namespace Assets.Scripts.Player
 
 		#endregion
 
+		#region Fields
+
+		/// <summary>
+		/// Timer to track how long since the last collision started.
+		/// </summary>
+		private float _collisionTimer;
+
+		#endregion
+
 		#region Properties
 
 		/// <summary>
@@ -212,6 +221,11 @@ namespace Assets.Scripts.Player
 		/// Speed by which the player character moves
 		/// </summary>
 		public float Speed;
+
+		/// <summary>
+		/// How long a continuous collision is tolerated before the state machine reacts.
+		/// </summary>
+		public float collisionTimerThreshold;
 
 		/// <summary>
 		/// Current state of the player
@@ -246,9 +260,19 @@ namespace Assets.Scripts.Player
 			State.OnUpdate();
 		}
 
+		private void OnCollisionEnter2D( Collision2D collision )
+		{
+			_collisionTimer = 0;
+		}
+
 		private void OnCollisionStay2D( Collision2D collision )
 		{
-			State.OnCollision( collision );
+			_collisionTimer += Time.deltaTime;
+			if(_collisionTimer >= collisionTimerThreshold)
+			{
+				_collisionTimer = 0;
+				State.OnCollision( collision );
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
Previously, we were using the OnCollisionStay2D() method to always call the state machine's State.OnCollision() method.  With these modifications there is a time threshold (in seconds, currently initially set to 2) that the player will continue to attempt movement while "sliding" along the wall it's collided with.  Each subsequent frame where the collision in question continues, the controller will add the time difference in seconds to the timer field, and if it's exceeded the threshold then it will react.  